### PR TITLE
Hide only parent element if it is nested content property container

### DIFF
--- a/src/NestingContently/backoffice/editor.controller.js
+++ b/src/NestingContently/backoffice/editor.controller.js
@@ -8,9 +8,12 @@
         
         const propElm = findAncestor($element[0], 'umb-property');
 
-        if (propElm) { 
-            propElm.parentElement.style.display = 'none';
-        } 
+        if (propElm) {
+            var parentElem = propElm.parentElement;
+            if (parentElem.classList.contains('umb-nested-content-property-container')) {
+                parentElem.style.display = 'none';
+            }
+        }
     } 
 
     angular.module('umbraco').controller('nestingContentlyController', ['$element', nestingContently]);


### PR DESCRIPTION
This fixes https://github.com/nathanwoulfe/NestingContently/issues/11 where it conflicted with e.g. DTGE and only hide the parent element if it is nested content property container.

![image](https://user-images.githubusercontent.com/2919859/61114886-95167180-a491-11e9-85d0-e1aab44ad27e.png)

![image](https://user-images.githubusercontent.com/2919859/61114965-b8412100-a491-11e9-9178-d3e5e02b2d59.png)