### PR TITLE
Hotfix:property inconsistency

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 2.1.0.{build}
+version: 2.1.1.{build}
 
 image: Visual Studio 2017
 
@@ -39,9 +39,9 @@ deploy:
         appveyor_repo_tag: true      
     
   - provider: GitHub
-    tag: v2.1.0
-    release: Release 2.1.0
-    description: "8.4 bugfixes"
+    tag: v2.1.1
+    release: Release 2.1.1
+    description: "Fix disabled properties inconsistency"
     force_update: true
     auth_token:
         secure: Otbl8p8qCwciDqJgSWCyN0Arfs5XS1CwiHcK+r0F6uz9Rxt4gzBFvlc3cjPV3NxR

--- a/src/NestingContently/backoffice/button.component.js
+++ b/src/NestingContently/backoffice/button.component.js
@@ -26,11 +26,13 @@
             
             prop.value = disabled ? "1" : "0";
 
-            this.model.value[this.index].disabled = prop.value;
+            this.model.value[this.index].disabled = disabled;
 
             if (this.model.value[this.index].hasOwnProperty('umbracoNaviHide')) {
-                this.model.value[this.index].umbracoNaviHide = disabled;
+                this.model.value[this.index].umbracoNaviHide = prop.value;
             }
+
+            console.log(this.model.value[this.index]);
             
             setTitle();
             setClass('toggle');

--- a/src/NestingContently/backoffice/button.component.js
+++ b/src/NestingContently/backoffice/button.component.js
@@ -24,10 +24,12 @@
         this.toggle = () => {
             disabled = !disabled;
             
-            prop.value = disabled ? 1 : 0;
+            prop.value = disabled ? "1" : "0";
 
-            this.model.value[this.index].disabled = disabled;
-         
+            if (this.model.value[this.index].hasOwnProperty('umbracoNaviHide')) {
+                this.model.value[this.index].umbracoNaviHide = prop.value;
+            }
+            
             setTitle();
             setClass('toggle');
         }
@@ -39,7 +41,7 @@
 
                 if (props.length === 1) {
                     prop = props[0];
-                    disabled = +prop.value === 1;
+                    disabled = prop.value === "1";
 
                     setTitle();
                     

--- a/src/NestingContently/backoffice/button.component.js
+++ b/src/NestingContently/backoffice/button.component.js
@@ -26,7 +26,7 @@
             
             prop.value = disabled ? "1" : "0";
 
-            this.model.value[this.index].disable = prop.value;
+            this.model.value[this.index].disabled = prop.value;
 
             if (this.model.value[this.index].hasOwnProperty('umbracoNaviHide')) {
                 this.model.value[this.index].umbracoNaviHide = disabled;

--- a/src/NestingContently/backoffice/button.component.js
+++ b/src/NestingContently/backoffice/button.component.js
@@ -26,8 +26,10 @@
             
             prop.value = disabled ? "1" : "0";
 
+            this.model.value[this.index].disable = prop.value;
+
             if (this.model.value[this.index].hasOwnProperty('umbracoNaviHide')) {
-                this.model.value[this.index].umbracoNaviHide = prop.value;
+                this.model.value[this.index].umbracoNaviHide = disabled;
             }
             
             setTitle();


### PR DESCRIPTION
# Hotfix: Property inconsistency

I'm experiencing issues with the v2.1.0 in Umbraco 8.4.0 where the setting seems to be a bit inconsistent. I then found out that the was because the `umbracoNaviHide` was not always being set.

The first issue occurres when reading the property since the value is stored as a number, but in a standard implementation of `umbracoNaviHide` it's actually stored as a string. See example:

![Screenshot_3](https://user-images.githubusercontent.com/6176830/72147351-9bcd6500-339e-11ea-90a8-f567c4479d33.png)

Besides that the `umbracoNaviHide` prop was set when I click the button the first time, but after that I'm not actually not able to reset it since the code only sets the `disabled` property on the model and not the `umbracoNaviHide`.

The code in this PR solves my issues, but let me hear what you think 😉

Thx for the package! It's a appreciated 👍 
