### PR TITLE
Hotfix: Change icon template markup to match markup in 8.6.0

### DIFF
--- a/src/NestingContently/backoffice/button.component.js
+++ b/src/NestingContently/backoffice/button.component.js
@@ -58,12 +58,12 @@
     }
  
     const template = `
-        <a class="umb-nested-content__icon umb-nested-content__icon--disable" 
+        <button type="button" class="umb-nested-content__icon umb-nested-content__icon--disable" 
             title="{{ $ctrl.iconTitle }}" 
             ng-click="$ctrl.toggle(); $event.stopPropagation()" 
             ng-class="$ctrl.disabledClass()" prevent-default>
             <i class="icon icon-power"></i>
-        </a>`;
+        </button>`;
 
     const component = {
         transclude: true,


### PR DESCRIPTION
# Hotfix: Change icon template markup to match markup in 8.6.0

The markup for icons in the nested content header has changed from a link to a button in Umbraco 8.6.0.

This impacts the layout of the icon row.
**Before:**
![image](https://user-images.githubusercontent.com/6176830/79308740-726e2900-7ef9-11ea-801a-f597290327a5.png)

**After:**
![image](https://user-images.githubusercontent.com/6176830/79308779-831e9f00-7ef9-11ea-9839-6adea4378927.png)
