### PR TITLE
Fix for Umbraco v8.7.0

### DIFF
--- a/src/NestingContently/backoffice/editor.controller.js
+++ b/src/NestingContently/backoffice/editor.controller.js
@@ -9,8 +9,8 @@
         const propElm = findAncestor($element[0], 'umb-property');
 
         if (propElm) {
-            var parentElem = propElm.parentElement;
-            if (parentElem.classList.contains('umb-nested-content-property-container')) {
+            var parentElem = findAncestor(propElm, 'umb-nested-content-property-container');
+            if (parentElem) {
                 parentElem.style.display = 'none';
             }
         }

--- a/src/NestingContently/backoffice/editor.controller.js
+++ b/src/NestingContently/backoffice/editor.controller.js
@@ -1,20 +1,12 @@
 ﻿(() => {
     // for this to work, we need a property editor, we don't, however, need it to be visible or edited...
     function nestingContently($element) {
-        const findAncestor = (el, cls) => {
-            while ((el = el.parentElement) && !el.classList.contains(cls));
-            return el;
-        }
-        
-        const propElm = findAncestor($element[0], 'umb-property');
+        const propElm = $element[0].closest('.umb-nested-content-property-container');
 
         if (propElm) {
-            var parentElem = findAncestor(propElm, 'umb-nested-content-property-container');
-            if (parentElem) {
-                parentElem.style.display = 'none';
-            }
+            propElm.style.display = 'none';
         }
-    } 
+    }
 
     angular.module('umbraco').controller('nestingContentlyController', ['$element', nestingContently]);
 })();


### PR DESCRIPTION
This fixes #22 by using the `.findAncestor()` function instead of directly going for the `.parentElement`.

A few questions though:

- Would it make sense to skip the '.umb-element' ancestor and directly target the `.umb-nested-content-property-container` right away?
- How do you feel about substituting the `.closest()` method for `.findAncestor()`? I noticed it's already being used in the [button.component.js][LINK] file. 

[LINK]: https://github.com/nathanwoulfe/NestingContently/blob/6417473675eb462df6b0fe52fd3b3dca86c8c774/src/NestingContently/backoffice/button.component.js#L19