### PR TITLE
Reorder entry.js imports

### DIFF
--- a/NestingContently.Umbraco/src/entry.js
+++ b/NestingContently.Umbraco/src/entry.js
@@ -1,3 +1,3 @@
+import "./app";
 import "./button.component";
 import "./editor.controller";
-import "./app";


### PR DESCRIPTION
This PR fixes https://github.com/nathanwoulfe/NestingContently/issues/27 by reordering the imports in `entry.js`.

Currently, `app.js` is imported after `button.component.js`:
https://github.com/nathanwoulfe/NestingContently/blob/1793c77b29e349e1809ae2854eaf9833ad193a43/NestingContently.Umbraco/src/entry.js#L1-L3

But `app.js` registers the `nc.components` module:
https://github.com/nathanwoulfe/NestingContently/blob/1793c77b29e349e1809ae2854eaf9833ad193a43/NestingContently.Umbraco/src/app.js#L3

And this module is injected in `button.component.js`:
https://github.com/nathanwoulfe/NestingContently/blob/1793c77b29e349e1809ae2854eaf9833ad193a43/NestingContently.Umbraco/src/button.component.js#L73

So the right order is to import `app.js` first, instead of last 😄

The previous gulp build didn't specify the order of files to import/combine, but because it used the default alphabetical file names, app.js was already first (or the order didn't matter at all, but I don't think that's the case).