### PR TITLE
Move UmbPack to build script

### DIFF
--- a/NestingContently.Umbraco/NestingContently.Umbraco.csproj
+++ b/NestingContently.Umbraco/NestingContently.Umbraco.csproj
@@ -19,7 +19,6 @@
 	</Target>  
 	<Target Name="UmbPack" AfterTargets="Pack">
 		<Exec Command="umbpack pack package.xml -v $(Version) -o $(PackageOutputPath)" />
-        <Exec Command="umbpack push $(PackageOutputPath)\Nesting_Contently_$(Version).zip -k $(UmbPackKey) -a current" Condition="$(APPVEYOR_REPO_TAG) == true" />
 	</Target>
 	<ItemGroup>
 		<Content Include="App_Plugins\NestingContently\**" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,9 +24,17 @@ build:
 test: off
 
 artifacts:
-  - path: '**\bin\$(configuration)\*.nupkg'
-  - path: '**\bin\$(configuration)\*.snupkg'
-  - path: '**\bin\$(configuration)\*.zip'
+  - path: 'NestingContently.Umbraco\bin\$(configuration)\*.nupkg'
+    name: NuGet_NestingContently
+  - path: 'NestingContently.Umbraco\bin\$(configuration)\*.zip'
+    name: UmbPack_NestingContently
+
+  - path: 'NestingContently.Umbraco.ValueConverters\bin\$(configuration)\*.nupkg'
+    name: NuGet_NestingContently_ValueConverters
+  - path: 'NestingContently.Umbraco.ValueConverters\bin\$(configuration)\*.snupkg'
+    name: NuGetSymbols_NestingContently_ValueConverters
+  - path: 'NestingContently.Umbraco.ValueConverters\bin\$(configuration)\*.zip'
+    name: UmbPack_NestingContently_ValueConverters
 
 deploy:
   - provider: NuGet
@@ -45,13 +53,11 @@ deploy:
 
 after_deploy:
   - ps: |
-      # Ensure we only push on tagged builds
-      if ($env:APPVEYOR_REPO_TAG -eq "true") {
-        foreach ($artifactName in $artifacts.keys) {
-          $path = $artifacts[$artifactName].path
-          # Only push the NestingContently Umbraco package
-          if ($path -match "Nesting_Contently_[0-9.]+\.zip$") {
-            umbpack push $path -k $env:UmbPackKey -a current
-          }
-        }
+      # Only run this script on tagged builds
+      if ($env:APPVEYOR_REPO_TAG -ne "true") { return }
+
+      # Push NestingContently Umbraco package
+      $path = $artifacts["UmbPack_NestingContently"].path
+      if ($path) {
+        umbpack push $path -k $env:UmbPackKey -a current
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,13 @@
 image: Visual Studio 2019
 
-cache:
-  - packages -> **\packages.config
-  - '%APPDATA%\npm-cache'
-  - '%LocalAppData%\NuGet\v3-cache'
-
 environment:
   UmbPackKey:
     secure: Y/76f3rkb4wyNyny/hPXqxyFyn1ttDUgCyKHKTEn8qUBP/GtRdZqD+bG5u4nhlccD1700FfRJsZgUp1qjRWKx8H4PsXmaRKklwJJ2fs4P+k=
   
+cache:
+  - '%APPDATA%\npm-cache'
+  - '%LocalAppData%\NuGet\v3-cache'
+
 install:
   - cmd: npm install --global parcel-bundler
   - cmd: dotnet tool install --global Umbraco.Tools.Packages
@@ -38,7 +37,21 @@ deploy:
 
   - provider: GitHub
     tag: $(APPVEYOR_REPO_TAG_NAME)
+    description: ''
     auth_token:
         secure: Otbl8p8qCwciDqJgSWCyN0Arfs5XS1CwiHcK+r0F6uz9Rxt4gzBFvlc3cjPV3NxR
     on:
         APPVEYOR_REPO_TAG: true
+
+after_deploy:
+  - ps: |
+      # Ensure we only push on tagged builds
+      if ($env:APPVEYOR_REPO_TAG -eq "true") {
+        foreach ($artifactName in $artifacts.keys) {
+          $path = $artifacts[$artifactName].path
+          # Only push the NestingContently Umbraco package
+          if ($path -match "Nesting_Contently_[0-9.]+\.zip$") {
+            umbpack push $path -k $env:UmbPackKey -a current
+          }
+        }
+      }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,4 +60,10 @@ after_deploy:
       $path = $artifacts["UmbPack_NestingContently"].path
       if ($path) {
         umbpack push $path -k $env:UmbPackKey -a current
+        
+        # Also push NestingContently ValueConverters Umbraco package
+        $path = $artifacts["UmbPack_NestingContently_ValueConverters"].path
+        if ($path) {
+          umbpack push $path -c false -k $env:UmbPackKey -a Nesting_Contently_Value_Converters_*
+        }
       }


### PR DESCRIPTION
This PR fixes https://github.com/nathanwoulfe/NestingContently/issues/26 by removing the `umbpack push` command from the project file to the build script.

I've also added an empty GitHub Releases description, as GitHub could otherwise return a `422: Unprocessable entity` error: https://www.appveyor.com/docs/deployment/github/#provider-settings.