### PR TITLE
Use UmbPack replaceable properties

### DIFF
--- a/NestingContently.Umbraco.ValueConverters/NestingContently.Umbraco.ValueConverters.csproj
+++ b/NestingContently.Umbraco.ValueConverters/NestingContently.Umbraco.ValueConverters.csproj
@@ -15,8 +15,8 @@
 		<NuspecFile>package.nuspec</NuspecFile>
 		<NuspecProperties>id=$(Id);version=$(Version);title=$(Title);description=$(Description);authors=$(Authors);projectUrl=$(PackageProjectUrl);license=$(PackageLicenseExpression);configuration=$(Configuration)</NuspecProperties>
 	</PropertyGroup>
-	<Target Name="UmbPack" AfterTargets="Pack" Condition="'$(Configuration)' == 'Release'">
-		<Exec Command="umbpack pack package.xml -v $(Version) -o $(PackageOutputPath)" />
+	<Target Name="UmbPack" AfterTargets="Pack">
+		<Exec Command="umbpack pack package.xml -v $(Version) -p &quot;$(NuspecProperties)&quot; -o $(PackageOutputPath)" />
 	</Target>
 	<ItemGroup>
 		<PackageReference Include="UmbracoCms.Core" Version="8.7.0" IncludeAssets="compile" />

--- a/NestingContently.Umbraco.ValueConverters/NestingContently.Umbraco.ValueConverters.csproj
+++ b/NestingContently.Umbraco.ValueConverters/NestingContently.Umbraco.ValueConverters.csproj
@@ -16,7 +16,7 @@
 		<NuspecProperties>id=$(Id);version=$(Version);title=$(Title);description=$(Description);authors=$(Authors);projectUrl=$(PackageProjectUrl);license=$(PackageLicenseExpression);configuration=$(Configuration)</NuspecProperties>
 	</PropertyGroup>
 	<Target Name="UmbPack" AfterTargets="Pack">
-		<Exec Command="umbpack pack package.xml -v $(Version) -p &quot;$(NuspecProperties)&quot; -o $(PackageOutputPath)" />
+		<Exec Command="umbpack pack package.xml -p &quot;$(NuspecProperties)&quot; -o $(PackageOutputPath)" />
 	</Target>
 	<ItemGroup>
 		<PackageReference Include="UmbracoCms.Core" Version="8.7.0" IncludeAssets="compile" />

--- a/NestingContently.Umbraco.ValueConverters/package.xml
+++ b/NestingContently.Umbraco.ValueConverters/package.xml
@@ -2,9 +2,9 @@
 <umbPackage>
 	<info>
 		<package>
-			<name>Nesting Contently Value Converters</name>
-			<licence url="https://opensource.org/licenses/MIT">MIT</licence>
-			<url>https://github.com/nathanwoulfe/nestingcontently</url>
+			<name>$title$</name>
+			<licence url="https://opensource.org/licenses/$license$">$license$</licence>
+			<url>$projectUrl$</url>
 			<requirements type="strict">
 				<major>8</major>
 				<minor>7</minor>
@@ -12,10 +12,10 @@
 			</requirements>
 		</package>
 		<author>
-			<name>Nathan Woulfe</name>
+			<name>$authors$</name>
 			<website>https://github.com/nathanwoulfe</website>
 		</author>
-		<readme><![CDATA[Property Value Converters for the NestingContently, Nested Content and Block List editors]]></readme>
+		<readme><![CDATA[$description$]]></readme>
 	</info>
 	<files>
 		<file path="bin/Release/net472/NestingContently.Umbraco.ValueConverters.dll" orgPath="bin/NestingContently.Umbraco.ValueConverters.dll" />

--- a/NestingContently.Umbraco.ValueConverters/package.xml
+++ b/NestingContently.Umbraco.ValueConverters/package.xml
@@ -3,6 +3,7 @@
 	<info>
 		<package>
 			<name>$title$</name>
+			<version>$version$</version>
 			<licence url="https://opensource.org/licenses/$license$">$license$</licence>
 			<url>$projectUrl$</url>
 			<requirements type="strict">

--- a/NestingContently.Umbraco/NestingContently.Umbraco.csproj
+++ b/NestingContently.Umbraco/NestingContently.Umbraco.csproj
@@ -21,7 +21,7 @@
 		<Exec Command="npm run publish" />
 	</Target>
 	<Target Name="UmbPack" AfterTargets="Pack">
-		<Exec Command="umbpack pack package.xml -v $(Version) -p &quot;$(NuspecProperties)&quot; -o $(PackageOutputPath)" />
+		<Exec Command="umbpack pack package.xml -p &quot;$(NuspecProperties)&quot; -o $(PackageOutputPath)" />
 	</Target>
 	<ItemGroup>
 		<Content Include="App_Plugins\NestingContently\**" />

--- a/NestingContently.Umbraco/NestingContently.Umbraco.csproj
+++ b/NestingContently.Umbraco/NestingContently.Umbraco.csproj
@@ -21,7 +21,7 @@
 		<Exec Command="npm run publish" />
 	</Target>
 	<Target Name="UmbPack" AfterTargets="Pack">
-		<Exec Command="umbpack pack package.xml -v $(Version) -o $(PackageOutputPath)" />
+		<Exec Command="umbpack pack package.xml -v $(Version) -p &quot;$(NuspecProperties)&quot; -o $(PackageOutputPath)" />
 	</Target>
 	<ItemGroup>
 		<Content Include="App_Plugins\NestingContently\**" />

--- a/NestingContently.Umbraco/package.xml
+++ b/NestingContently.Umbraco/package.xml
@@ -3,6 +3,7 @@
 	<info>
 		<package>
 			<name>$title$</name>
+			<version>$version$</version>
 			<licence url="https://opensource.org/licenses/$license$">$license$</licence>
 			<url>$projectUrl$</url>
 			<requirements type="strict">

--- a/NestingContently.Umbraco/package.xml
+++ b/NestingContently.Umbraco/package.xml
@@ -2,9 +2,9 @@
 <umbPackage>
 	<info>
 		<package>
-			<name>Nesting Contently</name>
-			<licence url="https://opensource.org/licenses/MIT">MIT</licence>
-			<url>https://github.com/nathanwoulfe/nestingcontently</url>
+			<name>$title$</name>
+			<licence url="https://opensource.org/licenses/$license$">$license$</licence>
+			<url>$projectUrl$</url>
 			<requirements type="strict">
 				<major>8</major>
 				<minor>0</minor>
@@ -12,10 +12,10 @@
 			</requirements>
 		</package>
 		<author>
-			<name>Nathan Woulfe</name>
+			<name>$authors$</name>
 			<website>https://github.com/nathanwoulfe</website>
 		</author>
-		<readme><![CDATA[A property editor for toggling the display state of Nested Content and Block List items]]></readme>
+		<readme><![CDATA[$description$]]></readme>
 	</info>
 	<files>
 		<folder path="App_Plugins/NestingContently" orgPath="App_Plugins/NestingContently" />


### PR DESCRIPTION
As commented earlier on https://github.com/nathanwoulfe/NestingContently/pull/25#issuecomment-702623492, now https://github.com/umbraco/UmbPack/pull/38 is merged, it's possible to use the properties from the project within the UmbPack command 🎉

You must use at least UmbPack 0.9.6, but since the AppVeyor build always installs the latest, you only have to ensure your local version is up-to-date. Code-wise, there are no changes, so no need to push out a new version right away 😴

Backporting this to v1 and v2 will be trivial, but let me know if you'd like separate PRs for this 😉 